### PR TITLE
Performance fix for large buffers of pending requests

### DIFF
--- a/src/RollingCurl/RollingCurl.php
+++ b/src/RollingCurl/RollingCurl.php
@@ -76,11 +76,6 @@ class RollingCurl
     private $pendingRequestsPosition = 0;
 
     /**
-     * @var int
-     */
-    private $pendingRequestsCount = 0;
-
-    /**
      * @var Request[]
      *
      * Requests currently being processed by curl
@@ -113,7 +108,6 @@ class RollingCurl
     public function add(Request $request)
     {
         $this->pendingRequests[] = $request;
-        $this->pendingRequestsCount += 1;
 
         return $this;
     }
@@ -462,8 +456,8 @@ class RollingCurl
     {
         $lastPosition = $this->pendingRequestsPosition + $limit;
 
-        if ($lastPosition > $this->pendingRequestsCount) {
-            $lastPosition = $this->pendingRequestsCount;
+        if ($lastPosition > count($this->pendingRequests)) {
+            $lastPosition = count($this->pendingRequests);
         }
 
         return $lastPosition;
@@ -526,12 +520,12 @@ class RollingCurl
     {
         $tmp = array();
 
-        for ($i = $this->pendingRequestsPosition; $i < $this->pendingRequestsCount; ++$i) {
+        $pendingRequestCount = count($this->pendingRequests);
+        for ($i = $this->pendingRequestsPosition; $i < $pendingRequestCount; ++$i) {
             $tmp[] = $this->pendingRequests[$i];
         }
 
         $this->pendingRequests         = $tmp;
-        $this->pendingRequestsCount    = count($this->pendingRequests);
         $this->pendingRequestsPosition = 0;
     }
 


### PR DESCRIPTION
I'll preface this by saying I'm not sure if you want to merge it.  It's a performance enhancement, but it trades some memory for a (rather drastic) increase in speed.

**The Problem**
Basically, large numbers of pending requests slow to a crawl.  The method getNextPendingRequests() uses array_splice on the pending queue to get the next range of requests to act on.

This is fine for small array sizes, but causes considerable memory thrashing when the buffer is large.  PHP copies the portion to be removed to a new array, then copies the remaining values to a new array variable.  

Given an array of 10,000 requests and splicing them out one at a time, you can see how most of the time is spent simply moving bytes around in memory.  Profiling in XDebug confirmed this as well.

**My Solution**
My solution is pretty simple, and arguably not very elegant.  Instead of splicing the array, I'm simply traversing the array with a pointer to the current position.  This is _a lot_ faster, but leaves the entire queue sitting in memory until it is cleaned up with getCompletedRequests().

For my use, this is a reasonable tradeoff.  If the queue residing in memory is big enough to cause memory problems, the data should be streamed from disk anyway (using the callback functionality of RollingCurl).
