### PR TITLE
Instantize options

### DIFF
--- a/src/RollingCurl/Request.php
+++ b/src/RollingCurl/Request.php
@@ -39,7 +39,7 @@ class Request
     /**
      * @var array
      */
-    private $options;
+    private $options = array();
     /**
      * @var mixed
      */
@@ -68,7 +68,6 @@ class Request
      */
     function __construct($url, $method="GET")
     {
-        $this->options = [];
         $this->setUrl($url);
         $this->setMethod($method);
     }


### PR DESCRIPTION
Under PHP 5.5 (at least), adding `null` to `Array` causes `Fatal error: Unsupported operand types`.
