### PR TITLE
Change setCallback to accept named functions as well

### DIFF
--- a/src/RollingCurl/RollingCurl.php
+++ b/src/RollingCurl/RollingCurl.php
@@ -369,6 +369,7 @@ class RollingCurl
      *   $rollingCurl is the rolling curl object itself (useful if you want to re/queue a URL)
      *
      * @param callable $callback
+     * @throws \InvalidArgumentException
      * @return RollingCurl
      */
     public function setCallback($callback)


### PR DESCRIPTION
I am using named functions as it makes my code less messy, since my callback functions do some heavy-lifting and putting them in the same scope as `setCallback` makes it crowded.

However, relying on the type typehint `\Closure` when trying to pass in a named function results in

> PHP Catchable fatal error:  Argument 1 passed to RollingCurl\RollingCurl::setCallback() must be an instance of Closure, array given, called in /index.php on line 23 and defined in /vendor/chuyskywalker/rolling-curl/src/RollingCurl/RollingCurl.php on line 358

My first solution was to change the type-hint to `callable` - it works for both named and anonymous functions but that would make it work only for PHP 5.4. 

Alternatively, checking with `is_callable` seems best as the same check is used when attempting to call it in 264.
