### PR TITLE
Add use of curl_multi_select to avoid burning CPU. (see 7e8432f)

### DIFF
--- a/src/RollingCurl/RollingCurl.php
+++ b/src/RollingCurl/RollingCurl.php
@@ -228,7 +228,6 @@ class RollingCurl
 
             // ensure we're running
             $status = curl_multi_exec($master, $active);
-
             // see if there is anything to read
             while ($transfer = curl_multi_info_read($master)) {
 
@@ -290,6 +289,9 @@ class RollingCurl
             if ($err) {
                 throw new \Exception("curl_multi_exec failed with error code ($status) const ($err)");
             }
+
+            curl_multi_select($master);
+
 
             // see if we're done yet or not
         } while ($status === CURLM_CALL_MULTI_PERFORM || $active);


### PR DESCRIPTION
Call of curl_multi_select($master) has disappeared. It should be used to avoid 100% processor load
