### PR TITLE
Add clearCompleted and prunePendingRequestQueue to google scraper sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ $rollingCurl
                 $results[$params['q']] = strip_tags($out[2][$idx]);
             }
         }
+
+        // Clear list of completed requests and prune pending request queue to avoid memory growth
+        $rollingCurl->clearCompleted();
+        $rollingCurl->prunePendingRequestQueue();
+
         echo "Fetch complete for (" . $request->getUrl() . ")" . PHP_EOL;
     })
     ->setSimultaneousLimit(10)


### PR DESCRIPTION
Recently we have experienced high memory usage in our long-running script which uses your library to make hundreds of requests (also see #12), I dived into the code and see these two methods which were created to solve this problem. So I add them to the sample code to make this behavior more public to people.